### PR TITLE
Clarify f5xc DNS name

### DIFF
--- a/docs/f5xc_k8s_site/http_lb.md
+++ b/docs/f5xc_k8s_site/http_lb.md
@@ -40,7 +40,7 @@ Follow the [F5 Distributed Cloud HTTP Load Balancer docs](https://docs.cloud.f5.
 
 Use the following settings:
 
-- List of Domains: brewz-<username>.<lab-app>.f5demos.com
+- List of Domains: brewz-*username*.*lab-app*.f5demos.com
     - Note: replace lab-app with a domain delegated to your F5XC organization, such as amer-ent.f5demos.com
 - Origin Pool: the SPA origin pool
 

--- a/docs/f5xc_k8s_site/http_lb.md
+++ b/docs/f5xc_k8s_site/http_lb.md
@@ -40,8 +40,8 @@ Follow the [F5 Distributed Cloud HTTP Load Balancer docs](https://docs.cloud.f5.
 
 Use the following settings:
 
-- List of Domains: brewz-username.lab-app.f5demos.com
-- Automatically Manage DNS Records: Check
+- List of Domains: brewz-<username>.<lab-app>.f5demos.com
+    - Note: replace lab-app with a domain delegated to your F5XC organization, such as amer-ent.f5demos.com
 - Origin Pool: the SPA origin pool
 
 ### Routes
@@ -60,9 +60,9 @@ The following settings should be modified from their default:
 
 Prefixes:
 
-- Inventory: /api/inventory
-- Recommendations: /api/recommendations
-- API: /api
+- /api/inventory: Inventory origin
+- /api/recommendations: Recommendations origin
+- /api: API origin
 
 Now we also need a route to direct /images requests to the API service.
 


### PR DESCRIPTION
Added a note to clarify that load balancer FQDN needs to be in a sub-domain that is delegated to the f5xc org in use.