### PR TITLE
Update virtualserver.md

### DIFF
--- a/docs/ingress/virtualserver.md
+++ b/docs/ingress/virtualserver.md
@@ -146,8 +146,6 @@ One of the advantages the NGINX Plus Ingress Controller provides is the ability 
           action:
             pass: spa
         - path: /api
-          policies:
-            - name: rate-limit-policy
           action:
             pass: api
         - path: /api/inventory


### PR DESCRIPTION
The rate-limit lines should be removed from the `virtual-server.yaml` manifest otherwise if this entire block is copied and pasted and then re-deployed the virtualserver goes into a warning state which in turn causes nginx ingress to respond with a 500 internal server error.